### PR TITLE
makes construction and deconstruction quicker

### DIFF
--- a/code/__DEFINES/construction/structures.dm
+++ b/code/__DEFINES/construction/structures.dm
@@ -30,14 +30,6 @@
 #define WINDOW_IN_FRAME 1
 #define WINDOW_SCREWED_TO_FRAME 2
 
-//reinforced window construction states
-#define RWINDOW_FRAME_BOLTED 3
-#define RWINDOW_BARS_CUT 4
-#define RWINDOW_POPPED 5
-#define RWINDOW_BOLTS_OUT 6
-#define RWINDOW_BOLTS_HEATED 7
-#define RWINDOW_SECURE 8
-
 //tram structure construction states
 #define TRAM_OUT_OF_FRAME 0
 #define TRAM_IN_FRAME 1

--- a/code/__DEFINES/construction/structures.dm
+++ b/code/__DEFINES/construction/structures.dm
@@ -35,8 +35,7 @@
 #define RWINDOW_BARS_CUT 4
 #define RWINDOW_POPPED 5
 #define RWINDOW_BOLTS_OUT 6
-#define RWINDOW_BOLTS_HEATED 7
-#define RWINDOW_SECURE 8
+#define RWINDOW_SECURE 7
 
 //tram structure construction states
 #define TRAM_OUT_OF_FRAME 0

--- a/code/__DEFINES/construction/structures.dm
+++ b/code/__DEFINES/construction/structures.dm
@@ -30,6 +30,14 @@
 #define WINDOW_IN_FRAME 1
 #define WINDOW_SCREWED_TO_FRAME 2
 
+//reinforced window construction states
+#define RWINDOW_FRAME_BOLTED 3
+#define RWINDOW_BARS_CUT 4
+#define RWINDOW_POPPED 5
+#define RWINDOW_BOLTS_OUT 6
+#define RWINDOW_BOLTS_HEATED 7
+#define RWINDOW_SECURE 8
+
 //tram structure construction states
 #define TRAM_OUT_OF_FRAME 0
 #define TRAM_IN_FRAME 1

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -21,7 +21,7 @@
 	var/state = WINDOW_OUT_OF_FRAME
 	var/reinf = FALSE
 	var/heat_resistance = 800
-	var/decon_speed = 10
+	var/decon_speed = 30
 	var/wtype = "glass"
 	var/fulltile = FALSE
 	var/glass_type = /obj/item/stack/sheet/glass
@@ -46,7 +46,10 @@
 	. = ..()
 	if(direct)
 		setDir(direct)
-	if(anchored)
+	if(reinf && anchored)
+		state = RWINDOW_SECURE
+
+	if(!reinf && anchored)
 		state = WINDOW_SCREWED_TO_FRAME
 
 	air_update_turf(TRUE, TRUE)
@@ -91,7 +94,7 @@
 
 /obj/structure/window/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_DECONSTRUCT)
-		return list("delay" = 2 SECONDS, "cost" = 2)
+		return list("delay" = 2 SECONDS, "cost" = 5)
 	return FALSE
 
 /obj/structure/window/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, list/rcd_data)
@@ -200,7 +203,7 @@
 	if(!tool.tool_start_check(user, amount = 0))
 		return FALSE
 	to_chat(user, span_notice("You begin repairing [src]..."))
-	if(tool.use_tool(src, user, 2 SECONDS, volume = 50))
+	if(tool.use_tool(src, user, 4 SECONDS, volume = 50))
 		atom_integrity = max_integrity
 		update_nearby_icons()
 		to_chat(user, span_notice("You repair [src]."))
@@ -237,7 +240,7 @@
 /obj/structure/window/wrench_act(mob/living/user, obj/item/tool)
 	if(anchored)
 		return FALSE
-	if(obj_flags & NO_DECONSTRUCTION)
+	if((obj_flags & NO_DECONSTRUCTION) || (reinf && state >= RWINDOW_FRAME_BOLTED))
 		return FALSE
 
 	to_chat(user, span_notice("You begin to disassemble [src]..."))
@@ -258,7 +261,7 @@
 	switch(state)
 		if(WINDOW_IN_FRAME)
 			to_chat(user, span_notice("You begin to lever the window out of the frame..."))
-			if(tool.use_tool(src, user, 5 SECONDS, volume = 75, extra_checks = CALLBACK(src, PROC_REF(check_state_and_anchored), state, anchored)))
+			if(tool.use_tool(src, user, 10 SECONDS, volume = 75, extra_checks = CALLBACK(src, PROC_REF(check_state_and_anchored), state, anchored)))
 				state = WINDOW_OUT_OF_FRAME
 				to_chat(user, span_notice("You pry the window out of the frame."))
 		if(WINDOW_OUT_OF_FRAME)
@@ -453,7 +456,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/unanchored/spawner, 0)
 	max_integrity = 75
 	explosion_block = 1
 	damage_deflection = 11
-	state = WINDOW_SCREWED_TO_FRAME
+	state = RWINDOW_SECURE
 	glass_type = /obj/item/stack/sheet/rglass
 	rad_insulation = RAD_LIGHT_INSULATION
 	receive_ricochet_chance_mod = 1.1
@@ -465,7 +468,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/unanchored/spawner, 0)
 //2021 AND STILLLL GOING STRONG
 //2022 BABYYYYY ~lewc
 //2023 ONE YEAR TO GO! -LT3
-//2024 fuck you all
 /datum/armor/window_reinforced
 	melee = 80
 	bomb = 25
@@ -474,10 +476,107 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/unanchored/spawner, 0)
 
 /obj/structure/window/reinforced/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_DECONSTRUCT)
-		return list("delay" = 3 SECONDS, "cost" = 5)
+		return list("delay" = 3 SECONDS, "cost" = 15)
 	return FALSE
 
+/obj/structure/window/reinforced/attackby_secondary(obj/item/tool, mob/user, params)
+	if(obj_flags & NO_DECONSTRUCTION)
+		return ..()
+
+	switch(state)
+		if(RWINDOW_SECURE)
+			if(tool.tool_behaviour == TOOL_WELDER)
+				if(tool.tool_start_check(user))
+					user.visible_message(span_notice("[user] holds \the [tool] to the security screws on \the [src]..."),
+						span_notice("You begin heating the security screws on \the [src]..."))
+					if(tool.use_tool(src, user, 15 SECONDS, volume = 100))
+						to_chat(user, span_notice("The security screws are glowing white hot and look ready to be removed."))
+						state = RWINDOW_BOLTS_HEATED
+						addtimer(CALLBACK(src, PROC_REF(cool_bolts)), 30 SECONDS)
+			else if (tool.tool_behaviour)
+				to_chat(user, span_warning("The security screws need to be heated first!"))
+
+		if(RWINDOW_BOLTS_HEATED)
+			if(tool.tool_behaviour == TOOL_SCREWDRIVER)
+				user.visible_message(span_notice("[user] digs into the heated security screws and starts removing them..."),
+										span_notice("You dig into the heated screws hard and they start turning..."))
+				if(tool.use_tool(src, user, 50, volume = 50))
+					state = RWINDOW_BOLTS_OUT
+					to_chat(user, span_notice("The screws come out, and a gap forms around the edge of the pane."))
+			else if (tool.tool_behaviour)
+				to_chat(user, span_warning("The security screws need to be removed first!"))
+
+		if(RWINDOW_BOLTS_OUT)
+			if(tool.tool_behaviour == TOOL_CROWBAR)
+				user.visible_message(span_notice("[user] wedges \the [tool] into the gap in the frame and starts prying..."),
+										span_notice("You wedge \the [tool] into the gap in the frame and start prying..."))
+				if(tool.use_tool(src, user, 40, volume = 50))
+					state = RWINDOW_POPPED
+					to_chat(user, span_notice("The panel pops out of the frame, exposing some thin metal bars that looks like they can be cut."))
+			else if (tool.tool_behaviour)
+				to_chat(user, span_warning("The gap needs to be pried first!"))
+
+		if(RWINDOW_POPPED)
+			if(tool.tool_behaviour == TOOL_WIRECUTTER)
+				user.visible_message(span_notice("[user] starts cutting the exposed bars on \the [src]..."),
+										span_notice("You start cutting the exposed bars on \the [src]"))
+				if(tool.use_tool(src, user, 20, volume = 50))
+					state = RWINDOW_BARS_CUT
+					to_chat(user, span_notice("The panels falls out of the way exposing the frame bolts."))
+			else if (tool.tool_behaviour)
+				to_chat(user, span_warning("The bars need to be cut first!"))
+
+		if(RWINDOW_BARS_CUT)
+			if(tool.tool_behaviour == TOOL_WRENCH)
+				user.visible_message(span_notice("[user] starts unfastening \the [src] from the frame..."),
+					span_notice("You start unfastening the bolts from the frame..."))
+				if(tool.use_tool(src, user, 40, volume = 50))
+					to_chat(user, span_notice("You unscrew the bolts from the frame and the window pops loose."))
+					state = WINDOW_OUT_OF_FRAME
+					set_anchored(FALSE)
+			else if (tool.tool_behaviour)
+				to_chat(user, span_warning("The bolts need to be loosened first!"))
+
+
+	if (tool.tool_behaviour)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	return ..()
+
+/obj/structure/window/reinforced/crowbar_act(mob/living/user, obj/item/tool)
+	if(!anchored)
+		return FALSE
+	if((obj_flags & NO_DECONSTRUCTION) || (state != WINDOW_OUT_OF_FRAME))
+		return FALSE
+	to_chat(user, span_notice("You begin to lever the window back into the frame..."))
+	if(tool.use_tool(src, user, 10 SECONDS, volume = 75, extra_checks = CALLBACK(src, PROC_REF(check_state_and_anchored), state, anchored)))
+		state = RWINDOW_SECURE
+		to_chat(user, span_notice("You pry the window back into the frame."))
+	return ITEM_INTERACT_SUCCESS
+
+/obj/structure/window/proc/cool_bolts()
+	if(state == RWINDOW_BOLTS_HEATED)
+		state = RWINDOW_SECURE
+		visible_message(span_notice("The bolts on \the [src] look like they've cooled off..."))
+
+/obj/structure/window/reinforced/examine(mob/user)
+	. = ..()
+	if(obj_flags & NO_DECONSTRUCTION)
+		return
+	switch(state)
+		if(RWINDOW_SECURE)
+			. += span_notice("It's been screwed in with one way screws, you'd need to <b>heat them</b> to have any chance of backing them out.")
+		if(RWINDOW_BOLTS_HEATED)
+			. += span_notice("The screws are glowing white hot, and you'll likely be able to <b>unscrew them</b> now.")
+		if(RWINDOW_BOLTS_OUT)
+			. += span_notice("The screws have been removed, revealing a small gap you could fit a <b>prying tool</b> in.")
+		if(RWINDOW_POPPED)
+			. += span_notice("The main plate of the window has popped out of the frame, exposing some bars that look like they can be <b>cut</b>.")
+		if(RWINDOW_BARS_CUT)
+			. += span_notice("The main pane can be easily moved out of the way to reveal some <b>bolts</b> holding the frame in.")
+
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/spawner, 0)
+
 /obj/structure/window/reinforced/unanchored
 	anchored = FALSE
 	state = WINDOW_OUT_OF_FRAME
@@ -600,7 +699,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/frosted/spaw
 	icon = 'icons/obj/smooth_structures/rplasma_window.dmi'
 	icon_state = "rplasma_window-0"
 	base_icon_state = "rplasma_window"
-	state = WINDOW_SCREWED_TO_FRAME
+	state = RWINDOW_SECURE
 	max_integrity = 1000
 	fulltile = TRUE
 	flags_1 = PREVENT_CLICK_UNDER_1
@@ -624,7 +723,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/frosted/spaw
 	fulltile = TRUE
 	flags_1 = PREVENT_CLICK_UNDER_1
 	obj_flags = CAN_BE_HIT
-	state = WINDOW_SCREWED_TO_FRAME
+	state = RWINDOW_SECURE
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = SMOOTH_GROUP_WINDOW_FULLTILE
 	canSmoothWith = SMOOTH_GROUP_WINDOW_FULLTILE


### PR DESCRIPTION
reduces deconstruction time for windows
reduces rcd costs
## About The Pull Request
## Why It's Good For The Game
This is Rimworld, we want encourage colonist to build things instead of discouraging them.
Alot of the construction steps are designed to discourage players from breaking into places. If your trying to build something these steps can become annoying. Additionally we would like the players to break into things!
## Changelog
:cl:
qol: made something easier to use
balance: rebalanced something
refactor: refactored some code
/:cl:
